### PR TITLE
Publish `Label`'s `Text` change.

### DIFF
--- a/label.go
+++ b/label.go
@@ -70,6 +70,8 @@ func (l *Label) SetText(value string) error {
 	if err := l.setText(value); err != nil {
 		return err
 	}
+	
+	l.textChangedPublisher.Publish()
 
 	return l.updateParentLayout()
 }


### PR DESCRIPTION
I found a question about `Label`, When I used `Label` to bind to another `Label`'s `Text`, The `Text` of the first `Label` is slower than the `Text` of the second `Label`.

![1234](https://user-images.githubusercontent.com/16683806/49493819-7a936e80-f898-11e8-8867-03a3b80e66ce.gif)

After modification:

![4321](https://user-images.githubusercontent.com/16683806/49494385-7bc59b00-f89a-11e8-8968-bd129f004323.gif)

Here's the code for this example: 

```go

package main

import (
	. "github.com/lxn/walk/declarative"
)

func main() {
	MainWindow{
		Title:   "Label Example",
		MinSize: Size{320, 240},
		Layout:  VBox{},
		Children: []Widget{
			Label{
				Text: Bind("lbSync3.Text"),
			}
			Label{
				Name: "lbSync3",
				Text: Bind("lbSync2.Text"),
			},
			Label{
				Name: "lbSync2",
				Text: Bind("lbSync1.Text"),
			},
			Label{
				Name: "lbSync1",
				Text: Bind("txtInput.Text"),
			},
			TextEdit{
				Name: "txtInput",
				Text: "hello",
			},
		},
	}.Run()
}
```

